### PR TITLE
feat: 주류 리뷰 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/org/complete/challang/common/dto/PageInfoDto.java
+++ b/src/main/java/org/complete/challang/common/dto/PageInfoDto.java
@@ -1,0 +1,27 @@
+package org.complete.challang.common.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PageInfoDto {
+
+    private int page;
+    private int size;
+    private long totalElements;
+    private String sort;
+
+    public static PageInfoDto toDto(int page,
+                                    int size,
+                                    long totalElements,
+                                    String sort) {
+        return PageInfoDto.builder()
+                .page(page)
+                .size(size)
+                .totalElements(totalElements)
+                .sort(sort)
+                .build();
+    }
+}

--- a/src/main/java/org/complete/challang/review/controller/ReviewController.java
+++ b/src/main/java/org/complete/challang/review/controller/ReviewController.java
@@ -5,13 +5,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.complete.challang.review.controller.dto.request.ReviewCreateRequest;
 import org.complete.challang.review.controller.dto.response.ReviewCreateResponse;
+import org.complete.challang.review.controller.dto.response.ReviewListFindResponse;
 import org.complete.challang.review.service.ReviewService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/reviews")
@@ -27,5 +25,14 @@ public class ReviewController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(reviewCreateResponse);
+    }
+
+    @GetMapping("?page={page_index}&sort={sort}")
+    public ResponseEntity<ReviewListFindResponse> findReviewList(@PathVariable("page_index") final int page,
+                                                                 @PathVariable("sort") final String sort) {
+        final ReviewListFindResponse reviewListFindResponse = reviewService.findReviewList(page, sort);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(reviewListFindResponse);
     }
 }

--- a/src/main/java/org/complete/challang/review/controller/dto/item/ReviewDto.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/item/ReviewDto.java
@@ -1,0 +1,32 @@
+package org.complete.challang.review.controller.dto.item;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import org.complete.challang.review.domain.entity.Review;
+
+import java.time.LocalDateTime;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ReviewDto {
+
+    private Long id;
+    private String imageUrl;
+    private double reviewRating;
+    private String writerNickname;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdDate;
+
+    public static ReviewDto toDto(final Review review) {
+        return ReviewDto.builder()
+                .id(review.getId())
+                .imageUrl(review.getImageUrl())
+                .reviewRating(review.getRating())
+                .writerNickname(review.getUser().getNickname())
+                .createdDate(review.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/org/complete/challang/review/controller/dto/response/ReviewListFindResponse.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/response/ReviewListFindResponse.java
@@ -1,0 +1,25 @@
+package org.complete.challang.review.controller.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import org.complete.challang.common.dto.PageInfoDto;
+import org.complete.challang.review.controller.dto.item.ReviewDto;
+
+import java.util.List;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ReviewListFindResponse {
+
+    private List<ReviewDto> reviews;
+    private PageInfoDto pageInfo;
+
+    public static ReviewListFindResponse toDto(final List<ReviewDto> reviews,
+                                               PageInfoDto pageInfo) {
+        return ReviewListFindResponse.builder()
+                .reviews(reviews)
+                .pageInfo(pageInfo)
+                .build();
+    }
+}

--- a/src/main/java/org/complete/challang/review/domain/entity/ReviewSortCriteria.java
+++ b/src/main/java/org/complete/challang/review/domain/entity/ReviewSortCriteria.java
@@ -1,0 +1,32 @@
+package org.complete.challang.review.domain.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewSortCriteria {
+
+    REVIEW_CREATED_DATE_DESC("latest", "최신순으로 정렬", Sort.by("created_date").descending()),
+    ;
+
+    private final String value;
+    private final String description;
+    private final Sort sortCriteria;
+
+    private static final Map<String, ReviewSortCriteria> BY_VALUE = new HashMap<>();
+
+    static {
+        for (ReviewSortCriteria e : values()) {
+            BY_VALUE.put(e.value, e);
+        }
+    }
+
+    public static Sort sortCriteriaOfValue(String value) {
+        return BY_VALUE.get(value).sortCriteria;
+    }
+}

--- a/src/main/java/org/complete/challang/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/org/complete/challang/review/domain/repository/ReviewRepository.java
@@ -1,7 +1,11 @@
 package org.complete.challang.review.domain.repository;
 
 import org.complete.challang.review.domain.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Page<Review> findAll(Pageable pageable);
 }


### PR DESCRIPTION
### 요약
- ReviewSortCriteria enum을 생성하여 주류 리뷰 정렬 API 호출 시 키워드로 검색 조건을 설정할 수 있도록 구성
- ReviewRepository에 pagable 파라미터를 받는 finAll 함수 생성
- ReveiwService에 주류 리뷰 리스트를 정렬 옵션을 선택해 받아올 수 있는 findReviewList 함수 생성
- ReveiwController에 주류 리뷰 리스트를 정렬 옵션을 선택해 받아올 수 있는 findReviewList get API 생성

### 관련 이슈
closed #27 