### PR TITLE
feat: 주류 리뷰 상세 조회 기능 구현

### DIFF
--- a/src/main/java/org/complete/challang/common/exception/ErrorCode.java
+++ b/src/main/java/org/complete/challang/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     DRINK_NOT_FOUND("음료 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
     FLAVOR_NOT_FOUND("향 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
     FOOD_NOT_FOUND("음식 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
+    REVIEW_NOT_FOUND("리뷰 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
     USER_NOT_FOUND("유저 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND);
 
     private final String message;

--- a/src/main/java/org/complete/challang/config/SecurityConfig.java
+++ b/src/main/java/org/complete/challang/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
         CorsConfiguration corsConfig = new CorsConfiguration();
         corsConfig.setAllowedHeaders(Arrays.asList("*"));
         corsConfig.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        corsConfig.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://challang.com"));
+        corsConfig.setAllowedOrigins(Arrays.asList("http://localhost:3003","http://localhost:3000", "https://challang.com"));
         corsConfig.setExposedHeaders(Arrays.asList("*"));
         corsConfig.setAllowCredentials(true);
         corsConfig.setMaxAge(corsConfig.getMaxAge());

--- a/src/main/java/org/complete/challang/review/controller/ReviewController.java
+++ b/src/main/java/org/complete/challang/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.complete.challang.review.controller.dto.request.ReviewCreateRequest;
 import org.complete.challang.review.controller.dto.response.ReviewCreateResponse;
+import org.complete.challang.review.controller.dto.response.ReviewDetailResponse;
 import org.complete.challang.review.controller.dto.response.ReviewListFindResponse;
 import org.complete.challang.review.service.ReviewService;
 import org.springframework.http.HttpStatus;
@@ -34,5 +35,13 @@ public class ReviewController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(reviewListFindResponse);
+    }
+
+    @GetMapping("/{review_id}")
+    public ResponseEntity<ReviewDetailResponse> findReviewDetail(@PathVariable("review_id") final Long reviewId) {
+        final ReviewDetailResponse reviewDetailResponse = reviewService.findReviewDetail(reviewId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(reviewDetailResponse);
     }
 }

--- a/src/main/java/org/complete/challang/review/controller/dto/item/SituationDto.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/item/SituationDto.java
@@ -32,4 +32,14 @@ public class SituationDto {
                 .partner(partner)
                 .build();
     }
+
+    public static SituationDto toDto(Situation situation) {
+        return SituationDto.builder()
+                .adult(situation.isAdult())
+                .alone(situation.isAlone())
+                .business(situation.isBusiness())
+                .friend(situation.isFriend())
+                .partner(situation.isPartner())
+                .build();
+    }
 }

--- a/src/main/java/org/complete/challang/review/controller/dto/item/TasteDto.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/item/TasteDto.java
@@ -32,4 +32,14 @@ public class TasteDto {
                 .refresh(refresh)
                 .build();
     }
+
+    public static TasteDto toDto(Taste taste) {
+        return TasteDto.builder()
+                .sweet(taste.getSweet())
+                .sour(taste.getSour())
+                .bitter(taste.getBitter())
+                .body(taste.getBody())
+                .refresh(taste.getRefresh())
+                .build();
+    }
 }

--- a/src/main/java/org/complete/challang/review/controller/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/response/ReviewDetailResponse.java
@@ -1,0 +1,38 @@
+package org.complete.challang.review.controller.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import org.complete.challang.review.controller.dto.item.SituationDto;
+import org.complete.challang.review.controller.dto.item.TasteDto;
+import org.complete.challang.review.domain.entity.Review;
+
+import java.util.List;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ReviewDetailResponse {
+
+    private String content;
+    private String imageUrl;
+    private float rating;
+    private SituationDto situation;
+    private TasteDto taste;
+    private List<String> flavors;
+    private List<String> foods;
+
+    public static ReviewDetailResponse toEntity(final Review review,
+                                                final SituationDto situationDto,
+                                                final TasteDto tasteDto,
+                                                final List<String> flavors,
+                                                final List<String> foods) {
+        return ReviewDetailResponse.builder()
+                .content(review.getContent())
+                .imageUrl(review.getImageUrl())
+                .situation(situationDto)
+                .taste(tasteDto)
+                .flavors(flavors)
+                .foods(foods)
+                .build();
+    }
+}


### PR DESCRIPTION
### 요약
- SecurityConfig에서 프런트 접속 허용 포트 추가
- ReveiwService에 주류 리뷰 리스트를 정렬 옵션을 선택해 받아올 수 있는 findReviewDetail 함수 생성
- ReveiwController에 주류 리뷰 리스트를 정렬 옵션을 선택해 받아올 수 있는 findReviewDetail get API 생성

### 관련 이슈
closed #16 