### PR TITLE
feat: 프로필 변경 기능 생성

### DIFF
--- a/src/main/java/org/complete/challang/account/user/controller/UserController.java
+++ b/src/main/java/org/complete/challang/account/user/controller/UserController.java
@@ -1,17 +1,17 @@
 package org.complete.challang.account.user.controller;
 
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.complete.challang.account.user.controller.dto.request.ProfileUpdateRequest;
+import org.complete.challang.account.user.controller.dto.response.ProfileUpdateResponse;
 import org.complete.challang.account.user.controller.dto.response.UserProfileFindResponse;
 import org.complete.challang.account.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/user")
@@ -28,5 +28,15 @@ public class UserController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(userProfileFindResponse);
+    }
+
+    @PatchMapping("/profile_image")
+    public ResponseEntity<ProfileUpdateResponse> updateProfile(@AuthenticationPrincipal final UserDetails user,
+                                                               @RequestBody @Valid ProfileUpdateRequest profileUpdateRequest) {
+        final Long userId = Long.parseLong(user.getUsername());
+        final ProfileUpdateResponse profileUpdateResponse = userService.updateProfile(userId, profileUpdateRequest);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(profileUpdateResponse);
     }
 }

--- a/src/main/java/org/complete/challang/account/user/controller/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/complete/challang/account/user/controller/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,20 @@
+package org.complete.challang.account.user.controller.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Email;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ProfileUpdateRequest {
+
+
+    private String profileImageUrl;
+    private String nickname;
+
+    @Email
+    private String email;
+}

--- a/src/main/java/org/complete/challang/account/user/controller/dto/response/ProfileUpdateResponse.java
+++ b/src/main/java/org/complete/challang/account/user/controller/dto/response/ProfileUpdateResponse.java
@@ -1,0 +1,25 @@
+package org.complete.challang.account.user.controller.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+import org.complete.challang.account.user.domain.entity.User;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ProfileUpdateResponse {
+
+    private String profileImageUrl;
+    private String nickname;
+    private String email;
+
+    public static ProfileUpdateResponse toDto(final User user) {
+        return ProfileUpdateResponse.builder()
+                .profileImageUrl(user.getProfileImageUrl())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/org/complete/challang/account/user/controller/dto/response/UserProfileFindResponse.java
+++ b/src/main/java/org/complete/challang/account/user/controller/dto/response/UserProfileFindResponse.java
@@ -11,6 +11,7 @@ import org.complete.challang.account.user.domain.entity.User;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class UserProfileFindResponse {
 
+    private Long userId;
     private String profileImageUrl;
     private String nickname;
     private String email;
@@ -20,6 +21,7 @@ public class UserProfileFindResponse {
     public static UserProfileFindResponse toDto(final User user,
                                                 final String email) {
         return UserProfileFindResponse.builder()
+                .userId(user.getId())
                 .profileImageUrl(user.getProfileImageUrl())
                 .nickname(user.getNickname())
                 .email(email)

--- a/src/main/java/org/complete/challang/account/user/domain/entity/User.java
+++ b/src/main/java/org/complete/challang/account/user/domain/entity/User.java
@@ -66,7 +66,19 @@ public class User extends BaseEntity {
                 .build();
     }
 
-    public void updateRefreshToken(String refreshToken) {
+    public void updateEmail(final String email) {
+        this.email = email;
+    }
+
+    public void updateNickname(final String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImageUrl(final String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateRefreshToken(final String refreshToken) {
         this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/org/complete/challang/account/user/domain/repository/UserRepository.java
+++ b/src/main/java/org/complete/challang/account/user/domain/repository/UserRepository.java
@@ -13,4 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByRefreshToken(String refreshToken);
 
     Optional<User> findByIdAndIsActiveTrue(Long userId);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/org/complete/challang/account/user/service/UserService.java
+++ b/src/main/java/org/complete/challang/account/user/service/UserService.java
@@ -1,6 +1,8 @@
 package org.complete.challang.account.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.complete.challang.account.user.controller.dto.request.ProfileUpdateRequest;
+import org.complete.challang.account.user.controller.dto.response.ProfileUpdateResponse;
 import org.complete.challang.account.user.controller.dto.response.UserProfileFindResponse;
 import org.complete.challang.account.user.domain.entity.User;
 import org.complete.challang.account.user.domain.repository.UserRepository;
@@ -8,7 +10,7 @@ import org.complete.challang.common.exception.ApiException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.complete.challang.common.exception.ErrorCode.USER_NOT_FOUND;
+import static org.complete.challang.common.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -16,7 +18,6 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    @Transactional
     public UserProfileFindResponse findUserProfile(final Long myId,
                                                    final Long userId) {
         User user;
@@ -31,5 +32,40 @@ public class UserService {
 
             return UserProfileFindResponse.toDto(user, null);
         }
+    }
+
+    @Transactional
+    public ProfileUpdateResponse updateProfile(final Long userId,
+                                               final ProfileUpdateRequest profileUpdateRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+
+        user.updateProfileImageUrl(profileUpdateRequest.getProfileImageUrl());
+        updateEmail(user, profileUpdateRequest.getEmail());
+        updateNickname(user, profileUpdateRequest.getNickname());
+
+        return ProfileUpdateResponse.toDto(user);
+    }
+
+    private void updateEmail(final User user,
+                             final String newEmail) {
+        if (user.getEmail() == newEmail) {
+            return;
+        }
+        if (userRepository.existsByEmail(newEmail)) {
+            new ApiException(EMAIL_CONFLICT);
+        }
+        user.updateEmail(newEmail);
+    }
+
+    private void updateNickname(final User user,
+                                final String newNickname) {
+        if (user.getNickname() == newNickname) {
+            return;
+        }
+        if (userRepository.existsByNickname(newNickname)) {
+            new ApiException(NICKNAME_CONFLICT);
+        }
+        user.updateNickname(newNickname);
     }
 }

--- a/src/main/java/org/complete/challang/common/exception/ErrorCode.java
+++ b/src/main/java/org/complete/challang/common/exception/ErrorCode.java
@@ -8,16 +8,21 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    DRINK_RATE_PARAM_INCORRECT("평가 조회 파라미터가 잘못되었습니다", HttpStatus.BAD_REQUEST),
+
+    UNAUTHORIZED("인증되지 않은 사용자입니다", HttpStatus.UNAUTHORIZED),
+
     REVIEW_REMOVE_FORBIDDEN("리뷰 삭제 접근 권한이 없습니다", HttpStatus.FORBIDDEN),
+    FORBIDDEN("권한이 없는 사용자입니다", HttpStatus.FORBIDDEN),
 
     DRINK_NOT_FOUND("음료 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
     FLAVOR_NOT_FOUND("향 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
     FOOD_NOT_FOUND("음식 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
     REVIEW_NOT_FOUND("리뷰 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
     USER_NOT_FOUND("유저 정보가 존재하지 않습니다", HttpStatus.NOT_FOUND),
-    DRINK_RATE_PARAM_INCORRECT("평가 조회 파라미터가 잘못되었습니다", HttpStatus.BAD_REQUEST),
-    UNAUTHORIZED("인증되지 않은 사용자입니다", HttpStatus.UNAUTHORIZED),
-    FORBIDDEN("권한이 없는 사용자입니다", HttpStatus.FORBIDDEN)
+
+    NICKNAME_CONFLICT("해당 닉네임이 이미 존재합니다.", HttpStatus.CONFLICT),
+    EMAIL_CONFLICT("해당 이메일이 이미 존재합니다.", HttpStatus.CONFLICT),
     ;
 
     private final String message;


### PR DESCRIPTION
### 요약
- 사용자 프로필 이미지 변경 기능 추가
- 이메일 중복 검사 및 변경기능 추가
- 닉네임 중복 검사 및 변경 기능 추가
- 사용자 프로필 정보 요청 시 사용자 ID가 같이 반환되도록 리펙토링

### 관련 이슈
closed #43 