### PR TITLE
fix: 팔로우 관련 에러 수정

### DIFF
--- a/src/main/java/org/complete/challang/account/user/domain/repository/FollowRepository.java
+++ b/src/main/java/org/complete/challang/account/user/domain/repository/FollowRepository.java
@@ -1,11 +1,12 @@
 package org.complete.challang.account.user.domain.repository;
 
 import org.complete.challang.account.user.domain.entity.Follow;
+import org.complete.challang.account.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
-    boolean existsByFromUserIdAndToUserId(final Long fromUserId, final Long toUserId);
+    boolean existsByFromUserAndToUser(final User fromUser, final User toUser);
 
-    void deleteByFromUserIdAndToUserID(final Long fromUserId, final Long toUserId);
+    void deleteByFromUserAndToUser(final User fromUser, final User toUser);
 }

--- a/src/main/java/org/complete/challang/account/user/service/UserService.java
+++ b/src/main/java/org/complete/challang/account/user/service/UserService.java
@@ -64,7 +64,7 @@ public class UserService {
         if (fromUser == toUSer) {
             throw new ApiException(INVALID_FOLLOW_REQUEST);
         }
-        if (followRepository.existsByFromUserIdAndToUserId(fromUser.getId(), toUSer.getId())) {
+        if (followRepository.existsByFromUserAndToUser(fromUser, toUSer)) {
             throw new ApiException(FOLLOW_CONFLICT);
         }
 
@@ -92,8 +92,11 @@ public class UserService {
     @Transactional
     public SuccessCode deleteFollow(final Long requestUserId,
                                     final Long targetUserId) {
+        final User requestUser = findUserById(requestUserId);
+        final User targetUser = findUserById(targetUserId);
 
-        followRepository.deleteByFromUserIdAndToUserID(requestUserId, targetUserId);
+        followRepository.deleteByFromUserAndToUser(requestUser, targetUser);
+
         return FOLLOW_DELETE_SUCCESS;
     }
 
@@ -152,6 +155,9 @@ public class UserService {
 
     private boolean checkFollow(final Long fromUserId,
                                 final Long toUserId) {
-        return followRepository.existsByFromUserIdAndToUserId(fromUserId, toUserId);
+        User fromUser = findUserById(fromUserId);
+        User toUser = findUserById(toUserId);
+
+        return followRepository.existsByFromUserAndToUser(fromUser, toUser);
     }
 }

--- a/src/main/java/org/complete/challang/config/SecurityConfig.java
+++ b/src/main/java/org/complete/challang/config/SecurityConfig.java
@@ -96,7 +96,6 @@ public class SecurityConfig {
         return corsConfigSource;
     }
 
-    @Bean
     public HttpCookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository() {
         return new HttpCookieOAuth2AuthorizationRequestRepository();
     }


### PR DESCRIPTION
### 요약
- SecurityConfig에 빈을 2번 등록하는 에러가 발생하여 HttpCookieOAuth2AuthorizationRequestRepository 를 빈으로 등록하는 어노테이션 삭제
- follow repository의 잘못 작성하여 에러가 발생하는 함수 수정

### 관련 이슈
closed #61 