### PR TITLE
feat: 리뷰 리스트 조회 및 상세 조회 관련 api 에러 수정

### DIFF
--- a/src/main/java/org/complete/challang/config/SecurityConfig.java
+++ b/src/main/java/org/complete/challang/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.complete.challang.account.oauth2.service.CustomOAuth2UserService;
 import org.complete.challang.handler.CustomAccessDeniedHandler;
 import org.complete.challang.handler.CustomAuthenticationEntryPoint;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -17,6 +18,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -49,12 +51,14 @@ public class SecurityConfig {
         http.httpBasic(HttpBasicConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .csrf(CsrfConfigurer::disable)
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .requestMatchers(HttpMethod.GET, "/drink/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/reviews/**").permitAll()
+                        .requestMatchers(PathRequest.toH2Console()).permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(

--- a/src/main/java/org/complete/challang/review/controller/dto/item/ReviewDto.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/item/ReviewDto.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
+import lombok.Getter;
 import org.complete.challang.review.domain.entity.Review;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ReviewDto {

--- a/src/main/java/org/complete/challang/review/controller/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/response/ReviewDetailResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
+import lombok.Getter;
 import org.complete.challang.review.controller.dto.item.SituationDto;
 import org.complete.challang.review.controller.dto.item.TasteDto;
 import org.complete.challang.review.controller.dto.item.WriterDto;
@@ -12,6 +13,7 @@ import org.complete.challang.review.domain.entity.Review;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Getter
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ReviewDetailResponse {

--- a/src/main/java/org/complete/challang/review/controller/dto/response/ReviewListFindResponse.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/response/ReviewListFindResponse.java
@@ -3,11 +3,13 @@ package org.complete.challang.review.controller.dto.response;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
+import lombok.Getter;
 import org.complete.challang.common.dto.PageInfoDto;
 import org.complete.challang.review.controller.dto.item.ReviewDto;
 
 import java.util.List;
 
+@Getter
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ReviewListFindResponse {


### PR DESCRIPTION
### 요약
- 시큐리티 설정에 h2 콘솔이 접근 가능하도록 허용
- response에 getter 어노테이션을 추가함으로서 DTO가  읽히도록 변경

### 관련 이슈
closed #64 