### PR TITLE
fix: 리뷰 작성 API 에러 수정

### DIFF
--- a/src/main/java/org/complete/challang/review/controller/dto/item/SituationDto.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/item/SituationDto.java
@@ -1,11 +1,12 @@
 package org.complete.challang.review.controller.dto.item;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 import org.complete.challang.review.domain.entity.Situation;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class SituationDto {
 
     @Builder.Default

--- a/src/main/java/org/complete/challang/review/controller/dto/item/TasteDto.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/item/TasteDto.java
@@ -1,11 +1,12 @@
 package org.complete.challang.review.controller.dto.item;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 import org.complete.challang.review.domain.entity.Taste;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class TasteDto {
 
     @Builder.Default

--- a/src/main/java/org/complete/challang/review/controller/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/request/ReviewCreateRequest.java
@@ -42,9 +42,7 @@ public class ReviewCreateRequest {
     private List<Long> foods;
 
     public Review toEntity(final Drink drink,
-                           final User user,
-                           final List<ReviewFlavor> reviewFlavors,
-                           final List<ReviewFood> reviewFoods) {
+                           final User user) {
         return Review.builder()
                 .imageUrl(imageUrl)
                 .rating(rating)
@@ -53,8 +51,6 @@ public class ReviewCreateRequest {
                 .taste(tasteDto.toEntity())
                 .drink(drink)
                 .user(user)
-                .reviewFlavors(reviewFlavors)
-                .reviewFoods(reviewFoods)
                 .build();
     }
 }

--- a/src/main/java/org/complete/challang/review/controller/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/org/complete/challang/review/controller/dto/request/ReviewCreateRequest.java
@@ -3,8 +3,7 @@ package org.complete.challang.review.controller.dto.request;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.*;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 import org.complete.challang.account.user.domain.entity.User;
 import org.complete.challang.drink.domain.entity.Drink;
 import org.complete.challang.review.controller.dto.item.SituationDto;
@@ -17,6 +16,8 @@ import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ReviewCreateRequest {
 

--- a/src/main/java/org/complete/challang/review/domain/entity/Review.java
+++ b/src/main/java/org/complete/challang/review/domain/entity/Review.java
@@ -46,14 +46,24 @@ public class Review extends BaseEntity {
     private User user;
 
     @Builder.Default
-    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewFlavor> reviewFlavors = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewFood> reviewFoods = new ArrayList<>();
 
     public void deleteReview() {
         super.delete();
+    }
+
+    public void addReviewFlavor(ReviewFlavor reviewFlavor) {
+        reviewFlavors.add(reviewFlavor);
+        reviewFlavor.updateReview(this);
+    }
+
+    public void addReviewFood(ReviewFood reviewFood) {
+        reviewFoods.add(reviewFood);
+        reviewFood.updateReview(this);
     }
 }

--- a/src/main/java/org/complete/challang/review/domain/entity/ReviewFlavor.java
+++ b/src/main/java/org/complete/challang/review/domain/entity/ReviewFlavor.java
@@ -21,4 +21,8 @@ public class ReviewFlavor extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Review review;
+
+    public void updateReview(Review review) {
+        this.review = review;
+    }
 }

--- a/src/main/java/org/complete/challang/review/domain/entity/ReviewFood.java
+++ b/src/main/java/org/complete/challang/review/domain/entity/ReviewFood.java
@@ -22,4 +22,8 @@ public class ReviewFood extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Review review;
+
+    public void updateReview(Review review) {
+        this.review = review;
+    }
 }


### PR DESCRIPTION
### 요약
- 리뷰 조회 시 생성자가 없어 발생하던 에러 수정
-  리뷰 생성 시 리뷰_향 리스트, 리뷰_음식 리스트를 생성 시 각 엔티티의 리뷰 필드가 업데이트 되지 않는 에러를 수정 및 불필요한 로직 삭제

### 관련 이슈
closed #66 