### PR TITLE
fix: Swagger 문서내 @AuthUser 어노테이션 관련 오류 해결

### DIFF
--- a/src/main/java/org/complete/challang/annotation/AuthUser.java
+++ b/src/main/java/org/complete/challang/annotation/AuthUser.java
@@ -1,5 +1,7 @@
 package org.complete.challang.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,5 +9,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
+@Parameter(hidden = true)
 public @interface AuthUser {
 }


### PR DESCRIPTION
### 요약
- @AuthUser 어노테이션이 붙은 파라미터를 입력하도록 요구하는 에러 해결
- @AuthUser 어노테이션 내 @Parameter(hidden=true)를 사용하여 파라미터 입력을 숨김

### 관련 이슈
closed #110 