### PR TITLE
hotfix: 주류 조합 작성 및 상세보기 swagger request/response 오류 해결

### DIFF
--- a/src/main/java/org/complete/challang/app/combination/controller/dto/item/CombinationCreateDto.java
+++ b/src/main/java/org/complete/challang/app/combination/controller/dto/item/CombinationCreateDto.java
@@ -16,10 +16,10 @@ public class CombinationCreateDto {
     private String name;
     private String volume;
 
-    @JsonProperty("x_coordinate")
+    @JsonProperty("xcoordinate")
     private int xCoordinate;
 
-    @JsonProperty("y_coordinate")
+    @JsonProperty("ycoordinate")
     private int yCoordinate;
 
     public Combination toEntity(CombinationBoard combinationBoard,

--- a/src/main/java/org/complete/challang/app/combination/controller/dto/item/CombinationFindDto.java
+++ b/src/main/java/org/complete/challang/app/combination/controller/dto/item/CombinationFindDto.java
@@ -1,5 +1,6 @@
 package org.complete.challang.app.combination.controller.dto.item;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
@@ -18,7 +19,11 @@ public class CombinationFindDto {
     private boolean drinkLike;
     private String name;
     private String volume;
+
+    @JsonProperty("xcoordinate")
     private int xCoordinate;
+
+    @JsonProperty("ycoordinate")
     private int yCoordinate;
 
     public static CombinationFindDto toDto(Combination combination,


### PR DESCRIPTION
### 요약
- x좌표 및 y좌표 표기 오류 해결 (snake 케이스 변환간 오류)
- 단일문자로 시작하는 경우의 문제로 인해 xcoordinate, ycoordinate로 request/response 표기

### 관련 이슈
