### PR TITLE
feat: 주류 조합 리스트 조회에 유저 이미지 url 추가

### DIFF
--- a/src/main/java/org/complete/challang/app/combination/controller/dto/response/CombinationBoardListFindResponse.java
+++ b/src/main/java/org/complete/challang/app/combination/controller/dto/response/CombinationBoardListFindResponse.java
@@ -13,19 +13,22 @@ import lombok.Getter;
 public class CombinationBoardListFindResponse {
 
     private Long combinationBoardId;
-    private String imageUrl;
+    private String combinationImageUrl;
     private String title;
+    private String profileImageUrl;
     private String nickname;
     private boolean combinationLike;
     private boolean combinationBookmark;
 
     public CombinationBoardListFindResponse(Long combinationBoardId,
-                                            String imageUrl,
+                                            String combinationImageUrl,
                                             String title,
+                                            String profileImageUrl,
                                             String nickname) {
         this.combinationBoardId = combinationBoardId;
-        this.imageUrl = imageUrl;
+        this.combinationImageUrl = combinationImageUrl;
         this.title = title;
+        this.profileImageUrl = profileImageUrl;
         this.nickname = nickname;
     }
 }

--- a/src/main/java/org/complete/challang/app/combination/domain/repository/CombinationBoardCustomRepository.java
+++ b/src/main/java/org/complete/challang/app/combination/domain/repository/CombinationBoardCustomRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.domain.Pageable;
 public interface CombinationBoardCustomRepository {
 
     Page<CombinationBoardListFindResponse> findAllBySorted(final CombinationSortCriteria combinationSortCriteria,
-                                                                  final Pageable pageable,
-                                                                  final Long userId);
+                                                           final Pageable pageable,
+                                                           final Long userId);
 }

--- a/src/main/java/org/complete/challang/app/combination/domain/repository/CombinationBoardCustomRepositoryImpl.java
+++ b/src/main/java/org/complete/challang/app/combination/domain/repository/CombinationBoardCustomRepositoryImpl.java
@@ -33,6 +33,7 @@ public class CombinationBoardCustomRepositoryImpl implements CombinationBoardCus
                                 combinationBoard.id,
                                 combinationBoard.imageUrl,
                                 combinationBoard.title,
+                                user.profileImageUrl,
                                 user.nickname
                         )
                 )


### PR DESCRIPTION
### 요약
- CombinationBoardListResponse에 profileImageUrl 변수 추가
- 주류 조합 리스트 조회 QueryDSL에 profileImageUrl 반환하도록 수정

### 관련 이슈
closed #125 